### PR TITLE
Add correct path to display HAL

### DIFF
--- a/services/surfaceflinger/Android.mk
+++ b/services/surfaceflinger/Android.mk
@@ -111,8 +111,8 @@ LOCAL_WHOLE_STATIC_LIBRARIES += libexsurfaceflinger
 LOCAL_C_INCLUDES += $(ANDROID_BUILD_TOP)/vendor/qcom/opensource/display-frameworks/native/services/surfaceflinger/
 
 ifeq ($(TARGET_USES_QCOM_BSP), true)
-    LOCAL_C_INCLUDES += hardware/qcom/display/libgralloc
-    LOCAL_C_INCLUDES += hardware/qcom/display/libqdutils
+    LOCAL_C_INCLUDES += $(call project-path-for,qcom-display)/libgralloc
+    LOCAL_C_INCLUDES += $(call project-path-for,qcom-display)/libqdutils
     LOCAL_C_INCLUDES += vendor/qcom/opensource/display-frameworks/include
     LOCAL_SHARED_LIBRARIES += libqdutils
     LOCAL_CFLAGS += -DQTI_BSP


### PR DESCRIPTION
We need this as display-caf from CyanogenMod is now being used
